### PR TITLE
Simple test included

### DIFF
--- a/simple_client/Gemfile
+++ b/simple_client/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem "stagger", git: "git@github.com:pusher/stagger-ruby-em.git", branch: "master"

--- a/simple_client/Gemfile.lock
+++ b/simple_client/Gemfile.lock
@@ -1,0 +1,27 @@
+GIT
+  remote: git@github.com:pusher/stagger-ruby-em.git
+  revision: f230f1602e7e268baaaa4dfec884a6cb06ab4973
+  branch: master
+  specs:
+    stagger (0.0.1)
+      em-zeromq (~> 0.4.2)
+      msgpack
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    em-zeromq (0.4.2)
+      eventmachine (>= 1.0.0)
+      ffi (>= 1.0.0)
+      ffi-rzmq (~> 1.0.1)
+    eventmachine (1.0.3)
+    ffi (1.9.3)
+    ffi-rzmq (1.0.3)
+      ffi
+    msgpack (0.5.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  stagger!

--- a/simple_client/test.rb
+++ b/simple_client/test.rb
@@ -1,0 +1,7 @@
+#!/usr/local/bin/ruby
+# -*- coding: utf-8 -*-
+require 'bundler/setup'
+require 'stagger'
+EM.run {
+  Stagger.default.register_value(:test){ Random.rand }
+}


### PR DESCRIPTION
We should include a simple test client for stagger in the repositiory (preferably in go, but this is ruby)
- There are many things which don't work when you don't have any clients
- You should be able to test stagger from just its own repo
- Depends on previous pull requests
- I don't care if this gets merged or not, as long as we have something
