### PR TITLE
SSL authentication setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-== On mac os x
+# Testing
+````
+cd simple_client
+bundle exec ruby test.rb
+````
+# Installing
+## On mac os x
 Download a go tarball to ~/go
 ````
 cd stagger
@@ -7,11 +13,21 @@ export PATH=$PATH:$GOROOT/bin
 export GOPATH=$PWD
 export GOBIN=$PWD
 brew install zeromq
-go build
+make
 ````
-== On linux
+## On linux
 ````
 apt-get install go libzmq3
 go get
 sudo go build
+````
+# Making/importing certificates
+Use easy-rsa3 to make a client certificate
+
+## On linux
+https://code.google.com/p/chromium/wiki/LinuxCertManagement
+
+## On mac
+````
+security import ca.crt -k ~/Library/Keychains/login.keychain
 ````

--- a/main.go
+++ b/main.go
@@ -51,16 +51,19 @@ func main() {
 	http_addr := flag.String("http", "127.0.0.1:8990", "HTTP debugging address (e.g. ':8990')")
 	https_addr := flag.String("https", "0.0.0.0:8443", "HTTPS address (e.g. ':8443')")
 	http_features_string := flag.String("features", "ws-json,http-json,sparkline", "HTTP features (ws-json,http-json,sparkline)")
-	http_features := make(map[string]bool)
+	ssl_crt := flag.String("crt", "", "SSL Certificate")
+	ssl_key := flag.String("key", "", "SSL Key")
+	ssl_ca := flag.String("ca", "", "Client certificate CA (If left unspecified, client certificates are not used)")
+	var showBuild = flag.Bool("build", false, "Print build information")
+	flag.Parse()
+        http_features := make(map[string]bool)
 	for _, s := range strings.Split(*http_features_string, ",") {
 		http_features[s] = true
 	}
-	ssl_crt := flag.String("crt", "easy-rsa/easyrsa3/pki/issued/stagger-server.crt", "Certificate")
-	ssl_key := flag.String("key", "easy-rsa/easyrsa3/pki/private/stagger-server.key", "Key")
-	ssl_ca := flag.String("ca", "easy-rsa/easyrsa3/pki/ca.crt", "Key")
-	var showBuild = flag.Bool("build", false, "Print build information")
-	flag.Parse()
-
+	if *ssl_crt == "" || *ssl_key == "" {
+		*https_addr = ""
+		info.Printf("[main] Either SSL crt (%v) and key (%v) left unspecified, disabling https interface", *ssl_crt, *ssl_key)
+	}
 	if *showBuild {
 		if len(build) > 0 {
 			fmt.Println(build)
@@ -98,7 +101,7 @@ func main() {
 	}
 	if *http_addr != "" || *https_addr != "" {
 		if _, ok := http_features["http-json"]; ok {
-			log.Println("Http json enabled at http://" + *http_addr + "/snapshot.json")
+			log.Println("[main] Http json enabled at http://" + *http_addr + "/snapshot.json")
 			snapshot := NewSnapshot()
 			output.Add(snapshot)
 			go func() {
@@ -106,7 +109,7 @@ func main() {
 			}()
 		}
 		if _, ok := http_features["ws-json"]; ok {
-			log.Println("Websocket json enabled at ws://" + *http_addr + "/ws.json")
+			log.Println("[main] Websocket json enabled at ws://" + *http_addr + "/ws.json")
 			websocketsender := NewWebsocketsender()
 			output.Add(websocketsender)
 			go func() {
@@ -114,7 +117,7 @@ func main() {
 			}()
 		}
 		if _, ok := http_features["sparkline"]; ok {
-			log.Println("Sparkline enabled at http://" + *http_addr + "/spark.html")
+			log.Println("[main] Sparkline enabled at http://" + *http_addr + "/spark.html")
 			js_data := []string{"/jquery.js", "/jquery.sparkline.js", "/jquery.appear.js", "/reconnecting-websocket.js"}
 
 			for _, n := range js_data {
@@ -140,23 +143,21 @@ func main() {
 		}
 		if *https_addr != "" {
 			go func() {
-				log.Print("loading key pair")
 				cert, err := tls.LoadX509KeyPair(*ssl_crt, *ssl_key)
 				if err != nil {
-					log.Fatalf("server: loadkeys: %s", err)
+					log.Fatalf("[main] loading key/crt pair: %s", err)
 				}
 				cp := x509.NewCertPool()
 				ca_data, err := ioutil.ReadFile(*ssl_ca)
 				if err != nil {
-					log.Fatalf("server: loadca: %s", err)
+					log.Fatalf("[main] loading ca: %s", err)
 				}
 				ca_decoded, _ := pem.Decode(ca_data)
 				x509cert, err := x509.ParseCertificate(ca_decoded.Bytes)
 				if err != nil {
-					log.Fatalf("Not x509?, %s", err)
+					log.Fatalf("[main] ca not x509?, %s", err)
 				}
 				cp.AddCert(x509cert)
-				log.Print("creating tls config")
 				config := tls.Config{
 					Certificates:       []tls.Certificate{cert},
 					ClientAuth:         tls.RequireAndVerifyClientCert,
@@ -164,7 +165,7 @@ func main() {
 					ClientCAs:          cp,
 					InsecureSkipVerify: true,
 					NextProtos:         []string{"http/1.1"},
-					CipherSuites: []uint16{
+					CipherSuites: []uint16{ // Work around chrome ssl certificate issue
 						tls.TLS_RSA_WITH_RC4_128_SHA,
 						tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 						tls.TLS_RSA_WITH_AES_128_CBC_SHA,

--- a/sparkline/spark.html
+++ b/sparkline/spark.html
@@ -20,7 +20,7 @@
        var ws = new ReconnectingWebSocket(host);
        ws.onmessage = function(evt) {
          data = JSON.parse(evt.data);
-         if(document.getElementById("set").childNodes.length>1)
+         if(document.getElementById("set").childNodes.length>0)
          { $('#waiting').remove() }
          //console.log(data)
          $.each(data["Dists"],function(k,v){

--- a/sparkline/spark.html
+++ b/sparkline/spark.html
@@ -10,7 +10,14 @@
     <script type="text/javascript">
     var stored_data = {};
     $(function() {
-       var ws = new ReconnectingWebSocket('ws://@@@@/ws.json');
+       if (document.location.protocol === 'https:') {
+         var host = 'wss://'+document.location.host+'/ws.json'
+       } else
+       {
+         var host = 'ws://'+document.location.host+'/ws.json'
+       }
+       console.log("Sparkline attempting to connect to",host)
+       var ws = new ReconnectingWebSocket(host);
        ws.onmessage = function(evt) {
          data = JSON.parse(evt.data);
          if(document.getElementById("set").childNodes.length>1)


### PR DESCRIPTION
(Note that this currently depends on the sparkline pull request)
- Adds support for a https endpoint. A https endpoint (8443) is created by default, if you pass a certificate (-crt) and key (-key) parameter
- Add support for client certificate authentication. Only used if a CA for the client certificate is passed in using the -ca parameter
- Ensures that the sparkline connects to the ssl webhook using the client certificate

Does not add support for 
- ZMQ SSL
